### PR TITLE
Replaced auto reset of max move speed

### DIFF
--- a/Assets/_Scripts/Units/Player/PlayerMovement.cs
+++ b/Assets/_Scripts/Units/Player/PlayerMovement.cs
@@ -94,7 +94,7 @@ namespace Units.Player
             }
             else
             {
-                currentMaxMoveSpeed = data.MoveMaximumSpeed;
+                currentMaxMoveSpeed = Mathf.MoveTowards(currentMaxMoveSpeed, data.MoveMaximumSpeed, data.SprintBraking);
             }
         }
 


### PR DESCRIPTION
I validated by changing the settings that this fixes it. The "bug" is simply that our values are a bit high so the player is very responsive.