### PR TITLE
moved tackle point back to avoid thinking we can reflect on a wall

### DIFF
--- a/Assets/Prefabs/Units/Player/PlayerEntity.prefab
+++ b/Assets/Prefabs/Units/Player/PlayerEntity.prefab
@@ -150,7 +150,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2224221380769967096}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 1, z: 0.75}
+  m_LocalPosition: {x: 0, y: 1, z: 0.375}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 7276514254351836702}
@@ -603,6 +603,8 @@ MonoBehaviour:
   mainCamera: {fileID: 2529432111249451232}
   customizationCamera: {fileID: 7955225160733818192}
   tacklePoint: {fileID: 5564205891444821671}
+  _CanDash:
+    _value: 1
   _TeamId: 
   _PlayerScore: 0
   _Archetype: 0


### PR DESCRIPTION
If you hug a wall and tackle you can sometime reflect off the wall instead of ragdoll. This fix insure we always include the player's position in our check to avoid unwanted behavior.